### PR TITLE
Fix JWT token typing and include Node types for compilation

### DIFF
--- a/src/api/routes/auth.routes.ts
+++ b/src/api/routes/auth.routes.ts
@@ -1,6 +1,6 @@
 import { Request, Response, Router } from 'express';
 import bcrypt from 'bcrypt';
-import jwt from 'jsonwebtoken';
+import jwt, { SignOptions, Secret } from 'jsonwebtoken';
 
 const router = Router();
 
@@ -31,10 +31,15 @@ router.post('/signup', async (req: Request, res: Response) => {
       weeklyRate
     };
 
+    const jwtSecret: Secret = process.env.JWT_SECRET || 'secret';
+    const signOptions: SignOptions = {
+      expiresIn: process.env.JWT_EXPIRES_IN || '7d'
+    };
+
     const token = jwt.sign(
       { userId: user.id, email: user.email },
-      process.env.JWT_SECRET || 'secret',
-      { expiresIn: process.env.JWT_EXPIRES_IN || '7d' }
+      jwtSecret,
+      signOptions
     );
 
     res.json({
@@ -61,10 +66,15 @@ router.post('/login', async (req: Request, res: Response) => {
   }
 
   try {
+    const jwtSecret: Secret = process.env.JWT_SECRET || 'secret';
+    const signOptions: SignOptions = {
+      expiresIn: process.env.JWT_EXPIRES_IN || '7d'
+    };
+
     const token = jwt.sign(
       { userId: 'user_123', email },
-      process.env.JWT_SECRET || 'secret',
-      { expiresIn: process.env.JWT_EXPIRES_IN || '7d' }
+      jwtSecret,
+      signOptions
     );
 
     res.json({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "commonjs",
     "lib": ["ES2022"],
+    "types": ["node"],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
## Summary
- ensure JWT signing uses typed secrets and options to satisfy TypeScript overloads
- configure the compiler to include Node type definitions for server-side globals

## Testing
- npm run build *(fails: missing @types/node due to npm install restrictions in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c3aeb980832cb5db8ecbfb91599a